### PR TITLE
[CHORE] An example folder structure and cmake file for MEML

### DIFF
--- a/examples/MEML/UART_example/README.md
+++ b/examples/MEML/UART_example/README.md
@@ -1,0 +1,22 @@
+# MEML UART example
+
+This example application demonstrates UART loopback on the XK-EVK-XU316.
+
+It effectively makes minimal modifications to the `explorer_board`'s bare metal
+example in order for that suite to run on the XK-EVK-XU316. Therefore all the 
+other, non UART demos are still running on the board (see the README for those
+examples for more detail) but have not been fully tested.
+
+In order for the loopback to work, you must connect Pin 36 on J10 to pin 39 on J16.
+
+## CMake Targets
+
+The following CMake targets are provided:
+
+- meml_uart_example
+- run_meml_uart_example
+- debug_meml_uart_example
+
+## Deploying the Firmware
+
+See the Programming Guide for information on building and running the application.

--- a/examples/MEML/UART_example/UART_example.cmake
+++ b/examples/MEML/UART_example/UART_example.cmake
@@ -1,0 +1,73 @@
+#**********************
+# Gather Sources
+#**********************
+file(GLOB_RECURSE APP_SOURCES ${CMAKE_CURRENT_LIST_DIR}/src/*.c )
+set(APP_INCLUDES
+    ${CMAKE_CURRENT_LIST_DIR}/src
+    ${CMAKE_CURRENT_LIST_DIR}/src/audio_pipeline
+    ${CMAKE_CURRENT_LIST_DIR}/src/platform
+    ${CMAKE_CURRENT_LIST_DIR}/src/misc
+    ${CMAKE_CURRENT_LIST_DIR}/src/demos
+)
+
+#**********************
+# Flags
+#**********************
+set(APP_COMPILER_FLAGS
+    -Os
+    -g
+    -report
+    -fxscope
+    -mcmodel=large
+    -Wno-xcore-fptrgroup
+    ${CMAKE_CURRENT_LIST_DIR}/src/config.xscope
+    ${CMAKE_CURRENT_LIST_DIR}/XK-EVK-XU316.xn
+)
+set(APP_COMPILE_DEFINITIONS
+    DEBUG_PRINT_ENABLE=1
+    PLATFORM_SUPPORTS_TILE_0=1
+    PLATFORM_SUPPORTS_TILE_1=1
+    PLATFORM_SUPPORTS_TILE_2=0
+    PLATFORM_SUPPORTS_TILE_3=0
+    PLATFORM_USES_TILE_0=1
+    PLATFORM_USES_TILE_1=1
+
+    MIC_ARRAY_CONFIG_CLOCK_BLOCK_A=XS1_CLKBLK_1
+    MIC_ARRAY_CONFIG_CLOCK_BLOCK_B=XS1_CLKBLK_2
+    MIC_ARRAY_CONFIG_PORT_MCLK=PORT_MCLK_IN
+    MIC_ARRAY_CONFIG_PORT_PDM_CLK=PORT_PDM_CLK
+    MIC_ARRAY_CONFIG_PORT_PDM_DATA=PORT_PDM_DATA
+    XUD_CORE_CLOCK=600
+)
+
+set(APP_LINK_OPTIONS
+    -lquadflash
+    -report
+    ${CMAKE_CURRENT_LIST_DIR}/XK-EVK-XU316.xn
+    ${CMAKE_CURRENT_LIST_DIR}/src/config.xscope
+)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+#**********************
+# Tile Targets
+#**********************
+add_executable(meml_uart_example)
+target_sources(meml_uart_example PUBLIC ${APP_SOURCES})
+target_include_directories(meml_uart_example PUBLIC ${APP_INCLUDES})
+target_compile_definitions(meml_uart_example PRIVATE ${APP_COMPILE_DEFINITIONS})
+target_compile_options(meml_uart_example PRIVATE ${APP_COMPILER_FLAGS})
+target_link_libraries(meml_uart_example PUBLIC core::general io::all framework_core_multitile_support)
+target_link_options(meml_uart_example PRIVATE ${APP_LINK_OPTIONS})
+
+# MCLK_FREQ,  PDM_FREQ, MIC_COUNT,  SAMPLES_PER_FRAME
+mic_array_vanilla_add( meml_uart_example
+    24576000  3072000   2           256 )
+
+#**********************
+# Create run and debug targets
+#**********************
+create_run_target(meml_uart_example)
+create_debug_target(meml_uart_example)
+create_flash_app_target(meml_uart_example)
+create_install_target(meml_uart_example)

--- a/examples/MEML/UART_example/XK-EVK-XU316.xn
+++ b/examples/MEML/UART_example/XK-EVK-XU316.xn
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Network xmlns="http://www.xmos.com"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.xmos.com http://www.xmos.com">
+  <Type>Board</Type>
+  <Name>xcore.ai Explorer Kit (XK-EVK-XU316)</Name>
+
+  <Declarations>
+    <Declaration>tileref tile[2]</Declaration>
+  </Declarations>
+
+  <Packages>
+    <Package id="0" Type="XS3-UnA-1024-FB265">
+      <Nodes>
+        <Node Id="0" InPackageId="0" Type="XS3-L16A-1024" Oscillator="24MHz" SystemFrequency="600MHz" ReferenceFrequency="100MHz">
+          <Boot>
+            <Source Location="bootFlash"/>
+          </Boot>
+          <Extmem sizeMbit="1024" Frequency="100MHz">
+            <!-- Attributes for Padctrl and Lpddr XML elements are as per equivalently named 'Node Configuration' registers in datasheet -->
+
+            <Padctrl clk="0x30" cke="0x30" cs_n="0x30" we_n="0x30" cas_n="0x30" ras_n="0x30" addr="0x30" ba="0x30" dq="0x31" dqs="0x31" dm="0x30"/>
+            <!--
+              Attributes all have the same meaning, which is:
+              [6] = Schmitt enable, [5] = Slew, [4:3] = drive strength, [2:1] = pull option, [0] = read enable
+
+              Therefore:
+              0x30: 8mA-drive, fast-slew output
+              0x31: 8mA-drive, fast-slew bidir
+            -->
+
+            <Lpddr emr_opcode="0x20" protocol_engine_conf_0="0x2aa"/>
+            <!--
+              Attributes have various meanings:
+              emr_opcode[7:5] = LPDDR drive strength to xcore.ai
+
+              protocol_engine_conf_0[23:21] = tWR clock count at the Extmem Frequency
+              protocol_engine_conf_0[20:15] = tXSR clock count at the Extmem Frequency
+              protocol_engine_conf_0[14:11] = tRAS clock count at the Extmem Frequency
+              protocol_engine_conf_0[10:0]  = tREFI clock count at the Extmem Frequency
+
+              Therefore:
+              0x20: Half drive strength
+              0x30b: tREFI 7.79us, tRAS 0us, tXSR 0us, tWR 0us
+            -->
+          </Extmem>
+          <Tile Number="0" Reference="tile[0]">
+            <Port Location="XS1_PORT_1B" Name="PORT_SQI_CS"/>
+            <Port Location="XS1_PORT_1C" Name="PORT_SQI_SCLK"/>
+            <Port Location="XS1_PORT_4B" Name="PORT_SQI_SIO"/>
+            
+            <Port Location="XS1_PORT_4C" Name="PORT_LEDS"/>
+            <Port Location="XS1_PORT_4D" Name="PORT_BUTTONS"/>
+            
+            <Port Location="XS1_PORT_1I"  Name="WIFI_WIRQ"/>
+            <Port Location="XS1_PORT_1J"  Name="WIFI_MOSI"/>
+            <Port Location="XS1_PORT_4E"  Name="WIFI_WUP_RST_N"/>
+            <Port Location="XS1_PORT_4F"  Name="WIFI_CS_N"/>
+            <Port Location="XS1_PORT_1L"  Name="WIFI_CLK"/>
+            <Port Location="XS1_PORT_1M"  Name="WIFI_MISO"/>
+          </Tile>
+          <Tile Number="1" Reference="tile[1]">
+            <!-- I2C ports -->
+            <Port Location="XS1_PORT_1N" Name="PORT_I2C_SCL"/>
+            <Port Location="XS1_PORT_1O" Name="PORT_I2C_SDA"/>
+
+            <!-- Mic related ports -->
+            <Port Location="XS1_PORT_1G" Name="PORT_PDM_CLK"/>
+            <Port Location="XS1_PORT_1F" Name="PORT_PDM_DATA"/>
+
+            <!-- Audio ports -->
+            <Port Location="XS1_PORT_1D" Name="PORT_MCLK_IN"/>
+            <Port Location="XS1_PORT_1C" Name="PORT_I2S_BCLK"/>
+            <Port Location="XS1_PORT_1B" Name="PORT_I2S_LRCLK"/>
+            <Port Location="XS1_PORT_1A" Name="PORT_I2S_DAC_DATA"/>
+            <Port Location="XS1_PORT_1N" Name="PORT_I2S_ADC_DATA"/>
+            <Port Location="XS1_PORT_4A" Name="PORT_CODEC_RST_N"/>
+          </Tile>
+        </Node>
+      </Nodes>
+    </Package>
+  </Packages>
+
+  <Nodes>
+    <Node Id="2" Type="device:" RoutingId="0x8000">
+      <Service Id="0" Proto="xscope_host_data(chanend c);">
+        <Chanend Identifier="c" end="3"/>
+      </Service>
+    </Node>
+  </Nodes>
+
+  <Links>
+    <Link Encoding="2wire" Delays="5clk" Flags="XSCOPE">
+      <LinkEndpoint NodeId="0" Link="XL0"/>
+      <LinkEndpoint NodeId="2" Chanend="1"/>
+    </Link>
+  </Links>
+
+  <ExternalDevices>
+    <Device NodeId="0" Tile="0" Class="SQIFlash" Name="bootFlash" PageSize="256" SectorSize="4096" NumPages="16384">
+      <Attribute Name="PORT_SQI_CS"   Value="PORT_SQI_CS"/>
+      <Attribute Name="PORT_SQI_SCLK" Value="PORT_SQI_SCLK"/>
+      <Attribute Name="PORT_SQI_SIO"  Value="PORT_SQI_SIO"/>
+    </Device>
+  </ExternalDevices>
+
+  <JTAGChain>
+    <JTAGDevice NodeId="0"/>
+  </JTAGChain>
+
+</Network>

--- a/examples/MEML/UART_example/src/app_conf.h
+++ b/examples/MEML/UART_example/src/app_conf.h
@@ -1,0 +1,21 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef APP_CONF_H_
+#define APP_CONF_H_
+
+/* Audio Pipeline Configuration */
+#define appconfAUDIO_FRAME_LENGTH            	MIC_ARRAY_CONFIG_SAMPLES_PER_FRAME
+#define appconfMIC_COUNT                        MIC_ARRAY_CONFIG_MIC_COUNT
+#define appconfFRAMES_IN_ALL_CHANS              (appconfAUDIO_FRAME_LENGTH * appconfMIC_COUNT)
+#define appconfEXP                              -31
+#define appconfINITIAL_GAIN                     20
+#define appconfAUDIO_PIPELINE_MAX_GAIN          60
+#define appconfAUDIO_PIPELINE_MIN_GAIN          0
+#define appconfAUDIO_PIPELINE_GAIN_STEP         4
+#define appconfPOWER_THRESHOLD                  (float)0.00001
+#define appconfAUDIO_CLOCK_FREQUENCY            24576000
+#define appconfPDM_CLOCK_FREQUENCY              3072000
+#define appconfPIPELINE_AUDIO_SAMPLE_RATE       16000
+
+#endif /* APP_CONF_H_ */

--- a/examples/MEML/UART_example/src/audio_pipeline/audio_pipeline.c
+++ b/examples/MEML/UART_example/src/audio_pipeline/audio_pipeline.c
@@ -1,0 +1,156 @@
+// Copyright 2021-2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* System headers */
+#include <platform.h>
+#include <xs1.h>
+#include <string.h>
+#include <xcore/triggerable.h>
+
+/* Platform headers */
+#include "xcore_utils.h"
+#include "mic_array.h"
+#include "xmath/xmath.h"
+
+/* App headers */
+#include "app_conf.h"
+#include "audio_pipeline.h"
+
+//#include <hwtimer.h>
+void ap_stage_a(chanend_t c_input, chanend_t c_output) {
+    // initialise the array which will hold the data
+    int32_t DWORD_ALIGNED input [appconfAUDIO_FRAME_LENGTH][appconfMIC_COUNT];
+    int32_t DWORD_ALIGNED output [appconfMIC_COUNT][appconfAUDIO_FRAME_LENGTH];
+
+    while(1)
+    {
+        // get the frame from the mic array
+        ma_frame_rx_transpose((int32_t *) input, c_input, appconfMIC_COUNT, appconfAUDIO_FRAME_LENGTH);
+        // change the frame format to [channel][sample]
+        for(int ch = 0; ch < appconfMIC_COUNT; ch ++){
+            for(int smp = 0; smp < appconfAUDIO_FRAME_LENGTH; smp ++){
+                output[ch][smp] = input[smp][ch];
+            }
+        }
+        // send the frame to the next stage
+        s_chan_out_buf_word(c_output, (uint32_t*) output, appconfFRAMES_IN_ALL_CHANS);
+    }
+}
+
+void ap_stage_b(chanend_t c_input, chanend_t c_output, chanend_t c_from_gpio) {
+    // initialise the array which will hold the data
+    int32_t DWORD_ALIGNED output[appconfMIC_COUNT][appconfAUDIO_FRAME_LENGTH];
+    // initialise block floating point structures for both channels
+    bfp_s32_t ch0, ch1;
+    bfp_s32_init(&ch0, output[0], appconfEXP, appconfAUDIO_FRAME_LENGTH, 0);
+    bfp_s32_init(&ch1, output[1], appconfEXP, appconfAUDIO_FRAME_LENGTH, 0);
+
+    int gain_db = appconfINITIAL_GAIN;
+
+    triggerable_disable_all();
+    // initialise events
+    TRIGGERABLE_SETUP_EVENT_VECTOR(c_input, input_frames);
+    TRIGGERABLE_SETUP_EVENT_VECTOR(c_from_gpio, gpio_request);
+
+    triggerable_enable_trigger(c_input);
+    triggerable_enable_trigger(c_from_gpio);
+
+    while(1)
+    {
+        TRIGGERABLE_WAIT_EVENT(input_frames, gpio_request);
+        {
+            input_frames:
+            {
+                // recieve frame over the channel
+                s_chan_in_buf_word(c_input, (uint32_t*) output, appconfFRAMES_IN_ALL_CHANS);
+                // calculate the headroom of the new frames
+                bfp_s32_headroom(&ch0);
+                bfp_s32_headroom(&ch1);
+                // update the gain
+                float power = (float)gain_db / 20.0;
+                float gain_fl = powf(10.0, power);
+                float_s32_t gain = f32_to_float_s32(gain_fl);
+                // scale both channels 
+                bfp_s32_scale(&ch0, &ch0, gain);
+                bfp_s32_scale(&ch1, &ch1, gain);
+                // normalise exponent
+                bfp_s32_use_exponent(&ch0, appconfEXP);
+                bfp_s32_use_exponent(&ch1, appconfEXP);
+                // send frame over the channel
+                s_chan_out_buf_word(c_output, (uint32_t*) output, appconfFRAMES_IN_ALL_CHANS);
+            }
+            continue;
+        }
+        {
+            gpio_request:
+            {
+                char msg = chanend_in_byte(c_from_gpio);
+                switch(msg)
+                {
+                default:
+                    break;
+                case 0x01:  /* Btn A */
+                    gain_db = (gain_db >= appconfAUDIO_PIPELINE_MAX_GAIN) ? gain_db : gain_db + appconfAUDIO_PIPELINE_GAIN_STEP;
+                    break;
+                case 0x02:  /* Btn B */
+                    gain_db = (gain_db <= appconfAUDIO_PIPELINE_MIN_GAIN) ? gain_db : gain_db - appconfAUDIO_PIPELINE_GAIN_STEP;
+                    break;
+                }
+                debug_printf("Gain set to %d\n", gain_db);
+            }
+            continue;
+        }
+    }
+}
+
+void ap_stage_c(chanend_t c_input, chanend_t c_output, chanend_t c_to_gpio) {
+
+    int32_t DWORD_ALIGNED input[appconfMIC_COUNT][appconfAUDIO_FRAME_LENGTH];
+    int32_t DWORD_ALIGNED output[appconfAUDIO_FRAME_LENGTH][appconfMIC_COUNT];
+    // initialise block floating point structures for both channels
+    bfp_s32_t ch0, ch1;
+    bfp_s32_init(&ch0, input[0], appconfEXP, appconfAUDIO_FRAME_LENGTH, 0);
+    bfp_s32_init(&ch1, input[1], appconfEXP, appconfAUDIO_FRAME_LENGTH, 0);
+
+    triggerable_disable_all();
+    // initialise event
+    TRIGGERABLE_SETUP_EVENT_VECTOR(c_input, input_frames);
+
+    triggerable_enable_trigger(c_input);
+
+    while(1)
+    {
+        TRIGGERABLE_WAIT_EVENT(input_frames);
+        {
+            input_frames:
+            {
+                uint8_t led_byte = 0;
+                // recieve frame over the channel
+                s_chan_in_buf_word(c_input, (uint32_t*) input, appconfFRAMES_IN_ALL_CHANS);
+                // calculate the headroom of the new frames
+                bfp_s32_headroom(&ch0);
+                bfp_s32_headroom(&ch1);
+                // calculate the frame energy
+                float_s32_t frame_energy_ch0 = float_s64_to_float_s32(bfp_s32_energy(&ch0));
+                float_s32_t frame_energy_ch1 = float_s64_to_float_s32(bfp_s32_energy(&ch1));
+                // calculate the frame power
+                float frame_pow0 = float_s32_to_float(frame_energy_ch0) / (float)appconfAUDIO_FRAME_LENGTH;
+                float frame_pow1 = float_s32_to_float(frame_energy_ch1) / (float)appconfAUDIO_FRAME_LENGTH;
+                if((frame_pow0 > appconfPOWER_THRESHOLD) || (frame_pow1 > appconfPOWER_THRESHOLD)){
+                    led_byte = 1;
+                }
+                // send led value to gpio
+                chanend_out_byte(c_to_gpio, led_byte);
+                // change the array format to [sample][channel]
+                for(int ch = 0; ch < appconfMIC_COUNT; ch ++){
+                    for(int smp = 0; smp < appconfAUDIO_FRAME_LENGTH; smp ++){
+                        output[smp][ch] = input[ch][smp];
+                    }
+                }
+                // send frame over the channel
+                s_chan_out_buf_word(c_output, (uint32_t*) output, appconfFRAMES_IN_ALL_CHANS);
+            }
+            continue;
+        }
+    }
+}

--- a/examples/MEML/UART_example/src/audio_pipeline/audio_pipeline.h
+++ b/examples/MEML/UART_example/src/audio_pipeline/audio_pipeline.h
@@ -1,0 +1,14 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef AUDIO_PIPELINE_H_
+#define AUDIO_PIPELINE_H_
+
+#include <xcore/parallel.h>
+#include <xcore/chanend.h>
+
+DECLARE_JOB(ap_stage_a, (chanend_t, chanend_t));
+DECLARE_JOB(ap_stage_b, (chanend_t, chanend_t, chanend_t));
+DECLARE_JOB(ap_stage_c, (chanend_t, chanend_t, chanend_t));
+
+#endif /* AUDIO_PIPELINE_H_ */

--- a/examples/MEML/UART_example/src/config.xscope
+++ b/examples/MEML/UART_example/src/config.xscope
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- ======================================================= -->
+<!-- The 'ioMode' attribute on the xSCOPEconfig              -->
+<!-- element can take the following values:                  -->
+<!--   "none", "basic", "timed"                              -->
+<!--                                                         -->
+<!-- The 'type' attribute on Probe                           -->
+<!-- elements can take the following values:                 -->
+<!--   "STARTSTOP", "CONTINUOUS", "DISCRETE", "STATEMACHINE" -->
+<!--                                                         -->
+<!-- The 'datatype' attribute on Probe                       -->
+<!-- elements can take the following values:                 -->
+<!--   "NONE", "UINT", "INT", "FLOAT"                        -->
+<!-- ======================================================= -->
+
+<xSCOPEconfig ioMode="basic" enabled="true">
+
+    <!-- For example: -->
+    <!-- <Probe name="Probe Name" type="CONTINUOUS" datatype="UINT" units="Value" enabled="true"/> -->
+    <!-- From the target code, call: xscope_int(PROBE_NAME, value); -->
+</xSCOPEconfig>

--- a/examples/MEML/UART_example/src/demos/app_demos.h
+++ b/examples/MEML/UART_example/src/demos/app_demos.h
@@ -1,0 +1,27 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef APP_DEMOS_H_
+#define APP_DEMOS_H_
+
+/* System headers */
+#include <platform.h>
+#include <xs1.h>
+#include <xcore/parallel.h>
+#include <xcore/chanend.h>
+
+#include <quadflash.h>
+#include <quadflashlib.h>
+
+/* Platform headers */
+#include "xcore_utils.h"
+#include "spi.h"
+#include "uart.h"
+
+DECLARE_JOB(spi_demo, (spi_master_device_t*));
+DECLARE_JOB(gpio_server, (chanend_t, chanend_t));
+DECLARE_JOB(flash_demo, (void));
+DECLARE_JOB(uart_rx_demo, (uart_rx_t *));
+DECLARE_JOB(uart_tx_demo, (uart_tx_t *));
+
+#endif /* APP_CONF_H_ */

--- a/examples/MEML/UART_example/src/demos/flash_demo.c
+++ b/examples/MEML/UART_example/src/demos/flash_demo.c
@@ -1,0 +1,12 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* App headers */
+#include "app_demos.h"
+
+void flash_demo(void)
+{
+	uint32_t flash_size = fl_getFlashSize();
+    debug_printf("Flash size: 0x%x\n", flash_size);
+    while(1) {;}
+}

--- a/examples/MEML/UART_example/src/demos/gpio_server.c
+++ b/examples/MEML/UART_example/src/demos/gpio_server.c
@@ -1,0 +1,100 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* System headers */
+#include <string.h>
+#include <xcore/port.h>
+#include <xcore/hwtimer.h>
+#include <xcore/triggerable.h>
+
+/* App headers */
+#include "app_demos.h"
+
+#define HEARTBEAT_TICKS 50000000
+
+void gpio_server(chanend_t c_from_gpio, chanend_t c_to_gpio)
+{
+    port_t p_leds = PORT_LEDS;
+    port_t p_btns = PORT_BUTTONS;
+    hwtimer_t tmr = hwtimer_alloc();
+
+    port_enable(p_leds);
+    port_enable(p_btns);
+
+    uint32_t led_val = 0;
+    uint32_t heartbeat_val = 0;
+    uint32_t btn_val = port_in(p_btns);
+
+    triggerable_disable_all();
+
+    TRIGGERABLE_SETUP_EVENT_VECTOR(p_btns, event_btn);
+    TRIGGERABLE_SETUP_EVENT_VECTOR(c_to_gpio, event_chan);
+    TRIGGERABLE_SETUP_EVENT_VECTOR(tmr, event_timer);
+
+    port_set_trigger_in_not_equal(p_btns, btn_val);
+    hwtimer_set_trigger_time(tmr, hwtimer_get_time(tmr) + HEARTBEAT_TICKS);
+
+    triggerable_enable_trigger(p_btns);
+    triggerable_enable_trigger(c_to_gpio);
+    triggerable_enable_trigger(tmr);
+
+    while(1)
+    {
+        TRIGGERABLE_WAIT_EVENT(event_btn, event_chan, event_timer);
+        {
+            event_btn:
+            {
+                btn_val = port_in(p_btns);
+                port_set_trigger_value(p_btns, btn_val);
+                int btn0 = ( btn_val >> 0 ) & 0x01;
+                int btn1 = ( btn_val >> 1 ) & 0x01;
+                if (btn0 == 0)
+                {
+                    debug_printf("Button A pressed\n");
+                    chanend_out_byte(c_from_gpio, 0x01);
+                    led_val |= 0x01;
+                } else {
+                    led_val &= ~0x01;
+                }
+
+                if (btn1 == 0)
+                {
+                    debug_printf("Button B pressed\n");
+                    chanend_out_byte(c_from_gpio, 0x02);
+                    led_val |= 0x02;
+                } else {
+                    led_val &= ~0x02;
+                }
+                port_out(p_leds, led_val);
+            }
+            continue;
+        }
+        {
+            event_chan:
+            {
+                char req_led_val = chanend_in_byte(c_to_gpio);
+                if (req_led_val != 0) {
+                    led_val |= 0x04;
+                } else {
+                    led_val &= ~0x04;
+                }
+                port_out(p_leds, led_val);
+            }
+            continue;
+        }
+        {
+            event_timer:
+            {
+                hwtimer_set_trigger_time(tmr, hwtimer_get_time(tmr) + HEARTBEAT_TICKS);
+                heartbeat_val ^= 1;
+                if (heartbeat_val != 0) {
+                    led_val |= 0x08;
+                } else {
+                    led_val &= ~0x08;
+                }
+                port_out(p_leds, led_val);
+            }
+            continue;
+        }
+    }
+}

--- a/examples/MEML/UART_example/src/demos/spi_demo.c
+++ b/examples/MEML/UART_example/src/demos/spi_demo.c
@@ -1,0 +1,21 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* App headers */
+#include "app_demos.h"
+
+void spi_demo(spi_master_device_t* device_ctx)
+{
+    uint32_t in_buf = 0;
+    uint32_t out_buf = 0;
+
+    spi_master_start_transaction(device_ctx);
+    spi_master_transfer(device_ctx,
+                        (uint8_t *)&out_buf,
+                        (uint8_t *)&in_buf,
+                        4);
+    spi_master_end_transaction(device_ctx);
+
+    debug_printf("SPI received: 0x%x\n", out_buf);
+    while(1) {;}
+}

--- a/examples/MEML/UART_example/src/demos/uart_demo.c
+++ b/examples/MEML/UART_example/src/demos/uart_demo.c
@@ -1,0 +1,58 @@
+// Copyright 2022 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* System headers */
+#include <platform.h>
+#include <xs1.h>
+#include <stdbool.h>
+
+/* Platform headers */
+#include "soc.h"
+#include "xcore_utils.h"
+#include "uart.h"
+
+/* App headers */
+#include "app_conf.h"
+#include "app_demos.h"
+
+static bool logged_error = false;
+
+void uart_rx_demo(uart_rx_t* uart_rx_ctx)
+{
+    uint8_t expected = 0;
+    debug_printf("Initialised UART RX\n");
+    while(1) {
+        debug_printf("Waiting to read UART\n");
+        uint8_t rx = uart_rx(uart_rx_ctx);
+        if(rx != expected && !logged_error){
+            debug_printf("UART data error, expected: %d got: %d\n", expected, rx);
+            debug_printf("Further UART errors will NOT be printed. Have you connected pins X1D00 and X1D11?\n\n");
+            logged_error = true;
+        }
+        debug_printf("Received: %u\n", expected);
+        expected++;
+    }
+}
+
+
+void uart_tx_demo(uart_tx_t* uart_tx_ctx)
+{
+    debug_printf("Starting tx ramp test @ %u baud..\n", XS1_TIMER_HZ / uart_tx_ctx->bit_time_ticks);
+
+    uint8_t tx_data = 0;
+    uint32_t time_now = get_reference_time();
+    while(get_reference_time() < (time_now + 100000)); // Wait for a millisecond
+
+    while(1) {
+        for(int i=0; i<256; i++){
+            uart_tx(uart_tx_ctx, tx_data);
+            debug_printf("Sent: %u\n", tx_data);
+            tx_data+=1;
+            uint32_t time_now = get_reference_time();
+            while(get_reference_time() < (time_now + 10000000)); // Wait for 100 milliseconds
+        }
+        uint32_t time_now = get_reference_time();
+        while(get_reference_time() < (time_now + 10000000)); // Wait for 100 milliseconds
+        //debug_printf("Sent: %u\n", tx_data);
+    }   
+}

--- a/examples/MEML/UART_example/src/main.c
+++ b/examples/MEML/UART_example/src/main.c
@@ -1,0 +1,56 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* App headers */
+#include "app_conf.h"
+#include "app_demos.h"
+#include "burn.h"
+#include "audio_pipeline.h"
+#include "platform_init.h"
+
+void main_tile0(chanend_t c0, chanend_t c1, chanend_t c2, chanend_t c3)
+{
+    (void)c0;
+    (void)c2;
+    (void)c3;
+
+    platform_init_tile_0(c1);
+
+    PAR_JOBS (
+        PJOB(spi_demo, (&tile0_ctx->spi_device_ctx)),
+        PJOB(gpio_server, (tile0_ctx->c_from_gpio, tile0_ctx->c_to_gpio)),
+        PJOB(flash_demo, ()),
+        PJOB(burn, ()),
+        PJOB(burn, ()),
+        PJOB(burn, ()),
+        PJOB(burn, ()),
+        PJOB(burn, ())
+    );
+}
+
+void main_tile1(chanend_t c0, chanend_t c1, chanend_t c2, chanend_t c3)
+{
+    (void)c1;
+    (void)c2;
+    (void)c3;
+
+    platform_init_tile_1(c0);
+
+    streaming_channel_t s_chan_ab = s_chan_alloc();
+    streaming_channel_t s_chan_bc = s_chan_alloc();
+    streaming_channel_t s_chan_output = s_chan_alloc();
+    channel_t chan_decoupler = chan_alloc();
+
+    tile1_ctx->c_i2s_to_dac = s_chan_output.end_b;
+
+    PAR_JOBS (
+        PJOB(ma_vanilla_task, (chan_decoupler.end_a)),
+        PJOB(ap_stage_a, (chan_decoupler.end_b, s_chan_ab.end_a)),
+        PJOB(ap_stage_b, (s_chan_ab.end_b, s_chan_bc.end_a, tile1_ctx->c_from_gpio)),
+        PJOB(ap_stage_c, (s_chan_bc.end_b, s_chan_output.end_a, tile1_ctx->c_to_gpio)),
+        PJOB(i2s_master, (&tile1_ctx->i2s_cb_group, tile1_ctx->p_i2s_dout, 1, NULL, 0, tile1_ctx->p_bclk, tile1_ctx->p_lrclk, tile1_ctx->p_mclk, tile1_ctx->bclk)),
+        PJOB(uart_rx_demo, (&tile1_ctx->uart_rx_ctx)),
+        PJOB(uart_tx_demo, (&tile1_ctx->uart_tx_ctx)),
+        PJOB(burn, ())
+    );
+}

--- a/examples/MEML/UART_example/src/misc/burn.h
+++ b/examples/MEML/UART_example/src/misc/burn.h
@@ -1,0 +1,16 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef BURN_H_
+#define BURN_H_
+
+#define SETSR(c) asm volatile("setsr %0" : : "n"(c));
+
+DECLARE_JOB(burn, (void));
+
+void burn(void) {
+    SETSR(XS1_SR_QUEUE_MASK | XS1_SR_FAST_MASK);
+    for(;;);
+}
+
+#endif /* BURN_H_ */

--- a/examples/MEML/UART_example/src/platform/aic3204.c
+++ b/examples/MEML/UART_example/src/platform/aic3204.c
@@ -1,0 +1,163 @@
+// Copyright 2020-2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+/* System headers */
+#include <platform.h>
+#include <xs1.h>
+
+/* Platform headers */
+#include "xcore_utils.h"
+#include "i2c.h"
+
+/* App headers */
+#include "aic3204.h"
+
+static i2c_master_t *l_i2c_master_ctx = 0;
+
+/*
+ * Writes a value to a register in the AIC3204 DAC chip.
+ */
+static inline int aic3204_reg_write(uint8_t reg, uint8_t val)
+{
+	i2c_regop_res_t ret;
+
+	ret = write_reg(l_i2c_master_ctx, AIC3204_I2C_DEVICE_ADDR, reg, val);
+
+	if (ret == I2C_REGOP_SUCCESS) {
+		return 0;
+	} else {
+        debug_printf("failed to write reg 0x%x val 0x%x\n", reg, val);
+		return -1;
+	}
+}
+
+/*
+ * Example configuration of the TLV320AIC3204 DAC using i2c.
+ *
+ * For details on the TLV320AIC3204 registers and configuration sequence,
+ * see chapters 4 and 5 here: https://www.ti.com/lit/ml/slaa557/slaa557.pdf
+ *
+ * Must be called after the RTOS scheduler is started.
+ */
+int aic3204_init(i2c_master_t *i2c_master_ctx)
+{
+    l_i2c_master_ctx = i2c_master_ctx;
+
+    if (l_i2c_master_ctx == 0) {
+        return -1;
+    }
+
+	if (
+		// Set register page to 0
+		aic3204_reg_write(AIC3204_PAGE_CTRL, 0x00) == 0 &&
+
+		// Initiate SW reset (PLL is powered off as part of reset)
+		aic3204_reg_write(AIC3204_SW_RST, 0x01) == 0 &&
+
+		// Program clock settings
+
+		// Default is CODEC_CLKIN is from MCLK pin. Don't need to change this.
+		// Power up NDAC and set to 1
+		aic3204_reg_write(AIC3204_NDAC, 0x81) == 0 &&
+		// Power up MDAC and set to 4
+		aic3204_reg_write(AIC3204_MDAC, 0x84) == 0 &&
+        // Power up NADC and set to 1
+		aic3204_reg_write(AIC3204_NADC, 0x81) == 0 &&
+        // Power up MADC and set to 4
+	    aic3204_reg_write(AIC3204_MADC, 0x84) == 0 &&
+		// Program DOSR = 128
+		aic3204_reg_write(AIC3204_DOSR, 0x80) == 0 &&
+        // Program AOSR = 128
+        aic3204_reg_write(AIC3204_AOSR, 0x80) == 0 &&
+		// Set Audio Interface Config: I2S, 24 bits, slave mode, DOUT always driving.
+		aic3204_reg_write(AIC3204_CODEC_IF, 0x20) == 0 &&
+		// Program the DAC processing block to be used - PRB_P1
+		aic3204_reg_write(AIC3204_DAC_SIG_PROC, 0x01) == 0 &&
+		// Program the ADC processing block to be used - PRB_R1
+        aic3204_reg_write(AIC3204_ADC_SIG_PROC, 0x01) == 0 &&
+		// Select Page 1
+		aic3204_reg_write(AIC3204_PAGE_CTRL, 0x01) == 0 &&
+		// Enable the internal AVDD_LDO:
+		aic3204_reg_write(AIC3204_LDO_CTRL, 0x09) == 0 &&
+
+		//
+		// Program Analog Blocks
+		// ---------------------
+		//
+		// Disable Internal Crude AVdd in presence of external AVdd supply or before powering up internal AVdd LDO
+		aic3204_reg_write(AIC3204_PWR_CFG, 0x08) == 0 &&
+		// Enable Master Analog Power Control
+		aic3204_reg_write(AIC3204_LDO_CTRL, 0x01) == 0 &&
+		// Set Common Mode voltages: Full Chip CM to 0.9V and Output Common Mode for Headphone to 1.65V and HP powered from LDOin @ 3.3V.
+		aic3204_reg_write(AIC3204_CM_CTRL, 0x33) == 0 &&
+		// Set PowerTune Modes
+		// Set the Left & Right DAC PowerTune mode to PTM_P3/4. Use Class-AB driver.
+		aic3204_reg_write(AIC3204_PLAY_CFG1, 0x00) == 0 &&
+		aic3204_reg_write(AIC3204_PLAY_CFG2, 0x00) == 0 &&
+		// Set ADC PowerTune mode PTM_R4.
+		aic3204_reg_write(AIC3204_ADC_PTM, 0x00) == 0 &&
+		// Set MicPGA startup delay to 3.1ms
+		aic3204_reg_write(AIC3204_AN_IN_CHRG, 0x31) == 0 &&
+		// Set the REF charging time to 40ms
+		aic3204_reg_write(AIC3204_REF_STARTUP, 0x01) == 0 &&
+		// HP soft stepping settings for optimal pop performance at power up
+		// Rpop used is 6k with N = 6 and soft step = 20usec. This should work with 47uF coupling
+		// capacitor. Can try N=5,6 or 7 time constants as well. Trade-off delay vs “pop” sound.
+		aic3204_reg_write(AIC3204_HP_START, 0x25) == 0 &&
+		// Route Left DAC to HPL
+		aic3204_reg_write(AIC3204_HPL_ROUTE, 0x08) == 0 &&
+		// Route Right DAC to HPR
+		aic3204_reg_write(AIC3204_HPR_ROUTE, 0x08) == 0 &&
+		// We are using Line input with low gain for PGA so can use 40k input R but lets stick to 20k for now.
+		// Route IN2_L to LEFT_P with 20K input impedance
+		aic3204_reg_write(AIC3204_LPGA_P_ROUTE, 0x20) == 0 &&
+		// Route IN2_R to LEFT_M with 20K input impedance
+		aic3204_reg_write(AIC3204_LPGA_N_ROUTE, 0x20) == 0 &&
+		// Route IN1_R to RIGHT_P with 20K input impedance
+		aic3204_reg_write(AIC3204_RPGA_P_ROUTE, 0x80) == 0 &&
+		// Route IN1_L to RIGHT_M with 20K input impedance
+		aic3204_reg_write(AIC3204_RPGA_N_ROUTE, 0x20) == 0 &&
+		// Unmute HPL and set gain to 0dB
+		aic3204_reg_write(AIC3204_HPL_GAIN, 0x00) == 0 &&
+		// Unmute HPR and set gain to 0dB
+		aic3204_reg_write(AIC3204_HPR_GAIN, 0x00) == 0 &&
+		// Unmute Left MICPGA, Set Gain to 0dB.
+		aic3204_reg_write(AIC3204_LPGA_VOL, 0x00) == 0 &&
+		// Unmute Right MICPGA, Set Gain to 0dB.
+		aic3204_reg_write(AIC3204_RPGA_VOL, 0x00) == 0 &&
+		// Power up HPL and HPR drivers
+		aic3204_reg_write(AIC3204_OP_PWR_CTRL, 0x30) == 0
+	) {
+		// Wait for 2.5 sec for soft stepping to take effect
+        hwtimer_t timer = hwtimer_alloc();
+        hwtimer_delay(timer, 250000);
+        hwtimer_free(timer);
+
+	} else {
+        debug_printf("Error during DAC configuration\n");
+		return -1;
+	}
+
+	if (
+		//
+		// Power Up DAC/ADC
+		// ----------------
+		//
+		// Select Page 0
+		aic3204_reg_write(AIC3204_PAGE_CTRL, 0x00) == 0 &&
+		// Power up the Left and Right DAC Channels. Route Left data to Left DAC and Right data to Right DAC.
+		// DAC Vol control soft step 1 step per DAC word clock.
+		aic3204_reg_write(AIC3204_DAC_CH_SET1, 0xd4) == 0 &&
+		// Power up Left and Right ADC Channels, ADC vol ctrl soft step 1 step per ADC word clock.
+		aic3204_reg_write(AIC3204_ADC_CH_SET, 0xc0) == 0 &&
+		// Unmute Left and Right DAC digital volume control
+		aic3204_reg_write(AIC3204_DAC_CH_SET2, 0x00) == 0 &&
+		// Unmute Left and Right ADC Digital Volume Control.
+		aic3204_reg_write(AIC3204_ADC_FGA_MUTE, 0x00) == 0
+	) {
+		return 0;
+	} else {
+        debug_printf("Error during DAC power up\n");
+		return -1;
+	}
+}

--- a/examples/MEML/UART_example/src/platform/aic3204.h
+++ b/examples/MEML/UART_example/src/platform/aic3204.h
@@ -1,0 +1,56 @@
+// Copyright 2020-2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef AIC3204_H_
+#define AIC3204_H_
+
+// TLV320AIC3204 Device I2C Address
+#define AIC3204_I2C_DEVICE_ADDR 0x18
+
+// TLV320AIC3204 Register Addresses
+// Page 0
+#define AIC3204_PAGE_CTRL     0x00 // Register 0  - Page Control
+#define AIC3204_SW_RST        0x01 // Register 1  - Software Reset
+#define AIC3204_NDAC          0x0B // Register 11 - NDAC Divider Value
+#define AIC3204_MDAC          0x0C // Register 12 - MDAC Divider Value
+#define AIC3204_DOSR          0x0E // Register 14 - DOSR Divider Value (LS Byte)
+#define AIC3204_NADC          0x12 // Register 18 - NADC Divider Value
+#define AIC3204_MADC          0x13 // Register 19 - MADC Divider Value
+#define AIC3204_AOSR          0x14 // Register 20 - AOSR Divider Value
+#define AIC3204_CODEC_IF      0x1B // Register 27 - CODEC Interface Control
+#define AIC3204_DAC_SIG_PROC  0x3C // Register 60 - DAC Sig Processing Block Control
+#define AIC3204_ADC_SIG_PROC  0x3D // Register 61 - ADC Sig Processing Block Control
+#define AIC3204_DAC_CH_SET1   0x3F // Register 63 - DAC Channel Setup 1
+#define AIC3204_DAC_CH_SET2   0x40 // Register 64 - DAC Channel Setup 2
+#define AIC3204_DACL_VOL_D    0x41 // Register 65 - DAC Left Digital Vol Control
+#define AIC3204_DACR_VOL_D    0x42 // Register 66 - DAC Right Digital Vol Control
+#define AIC3204_ADC_CH_SET    0x51 // Register 81 - ADC Channel Setup
+#define AIC3204_ADC_FGA_MUTE  0x52 // Register 82 - ADC Fine Gain Adjust/Mute
+
+// Page 1
+#define AIC3204_PWR_CFG       0x01 // Register 1  - Power Config
+#define AIC3204_LDO_CTRL      0x02 // Register 2  - LDO Control
+#define AIC3204_PLAY_CFG1     0x03 // Register 3  - Playback Config 1
+#define AIC3204_PLAY_CFG2     0x04 // Register 4  - Playback Config 2
+#define AIC3204_OP_PWR_CTRL   0x09 // Register 9  - Output Driver Power Control
+#define AIC3204_CM_CTRL       0x0A // Register 10 - Common Mode Control
+#define AIC3204_HPL_ROUTE     0x0C // Register 12 - HPL Routing Select
+#define AIC3204_HPR_ROUTE     0x0D // Register 13 - HPR Routing Select
+#define AIC3204_HPL_GAIN      0x10 // Register 16 - HPL Driver Gain
+#define AIC3204_HPR_GAIN      0x11 // Register 17 - HPR Driver Gain
+#define AIC3204_HP_START      0x14 // Register 20 - Headphone Driver Startup
+#define AIC3204_LPGA_P_ROUTE  0x34 // Register 52 - Left PGA Positive Input Route
+#define AIC3204_LPGA_N_ROUTE  0x36 // Register 54 - Left PGA Negative Input Route
+#define AIC3204_RPGA_P_ROUTE  0x37 // Register 55 - Right PGA Positive Input Route
+#define AIC3204_RPGA_N_ROUTE  0x39 // Register 57 - Right PGA Negative Input Route
+#define AIC3204_LPGA_VOL      0x3B // Register 59 - Left PGA Volume
+#define AIC3204_RPGA_VOL      0x3C // Register 60 - Right PGA Volume
+#define AIC3204_ADC_PTM       0x3D // Register 61 - ADC Power Tune Config
+#define AIC3204_AN_IN_CHRG    0x47 // Register 71 - Analog Input Quick Charging Config
+#define AIC3204_REF_STARTUP   0x7B // Register 123 - Reference Power Up Config
+
+#include "i2c.h"
+
+int aic3204_init(i2c_master_t *i2c_master_ctx);
+
+#endif /* AIC3204_H_ */

--- a/examples/MEML/UART_example/src/platform/app_pll_ctrl.c
+++ b/examples/MEML/UART_example/src/platform/app_pll_ctrl.c
@@ -1,0 +1,51 @@
+// Copyright (c) 2021 XMOS LIMITED. This Software is subject to the terms of the
+// XMOS Public License: Version 1
+
+/* System headers */
+#include <platform.h>
+#include <xs1.h>
+#include <xcore/hwtimer.h>
+#include <xcore/assert.h>
+
+/* App headers */
+#include "app_pll_ctrl.h"
+
+void app_pll_set_numerator(int numerator)
+{
+    const unsigned tileid = get_local_tile_id();
+    uint32_t fracval = APP_PLL_FRAC_NOM & 0xFFFF00FF;
+    uint32_t f;
+
+    if (numerator > 255) {
+        f = 255;
+    } else if (numerator < 0) {
+        f = 0;
+    } else {
+        f = numerator;
+    }
+
+    fracval |= (f << 8);
+    write_sswitch_reg_no_ack(tileid, XS1_SSWITCH_SS_APP_PLL_FRAC_N_DIVIDER_NUM, fracval);
+}
+
+void app_pll_init(void)
+{
+    unsigned tileid = get_local_tile_id();
+
+    const unsigned APP_PLL_DISABLE = 0x0201FF04;
+    const unsigned APP_PLL_DIV_0   = 0x80000004;
+
+    write_sswitch_reg(tileid, XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_DISABLE);
+
+    hwtimer_t tmr = hwtimer_alloc();
+    {
+        xassert(tmr != 0);
+        hwtimer_delay(tmr, 100000); // 1ms with 100 MHz timer tick
+    }
+    hwtimer_free(tmr);
+
+    write_sswitch_reg(tileid, XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_VAL);
+    write_sswitch_reg(tileid, XS1_SSWITCH_SS_APP_PLL_CTL_NUM, APP_PLL_CTL_VAL);
+    write_sswitch_reg(tileid, XS1_SSWITCH_SS_APP_PLL_FRAC_N_DIVIDER_NUM, APP_PLL_FRAC_NOM);
+    write_sswitch_reg(tileid, XS1_SSWITCH_SS_APP_CLK_DIVIDER_NUM, APP_PLL_DIV_0);
+}

--- a/examples/MEML/UART_example/src/platform/app_pll_ctrl.h
+++ b/examples/MEML/UART_example/src/platform/app_pll_ctrl.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 XMOS LIMITED. This Software is subject to the terms of the
+// XMOS Public License: Version 1
+
+#ifndef APP_PLL_CTRL_H_
+#define APP_PLL_CTRL_H_
+
+#include "app_conf.h"
+
+#if (appconfAUDIO_CLOCK_FREQUENCY != 24576000)
+#error PLL values only valid if appconfAUDIO_CLOCK_FREQUENCY == 24576000
+#endif
+
+#define APP_PLL_CTL_VAL   0x0A019803 // Valid for all fractional values
+#define APP_PLL_FRAC_NOM  0x800095F9 // 24.576000 MHz
+
+void app_pll_set_numerator(int numerator);
+void app_pll_init(void);
+
+#endif /* APP_PLL_CTRL_H_ */

--- a/examples/MEML/UART_example/src/platform/mic_support.h
+++ b/examples/MEML/UART_example/src/platform/mic_support.h
@@ -1,0 +1,61 @@
+// Copyright 2021 XMOS LIMITED.
+// This Software is subject to the terms of the XMOS Public Licence: Version 1.
+
+#ifndef MIC_SUPPORT_H_
+#define MIC_SUPPORT_H_
+
+#include <xcore/clock.h>
+#include <xcore/port.h>
+
+#include "app_conf.h"
+
+void mic_array_setup_ddr(
+        xclock_t pdmclk,
+        xclock_t pdmclk6,
+        port_t p_mclk,
+        port_t p_pdm_clk,
+        port_t p_pdm_mics,
+        int divide);
+
+void frame_power(int32_t (*audio_frame)[appconfMIC_COUNT]);
+
+inline int mic_array_decimation_factor(
+        const unsigned pdm_clock_frequency,
+        const unsigned sample_rate)
+{
+    return pdm_clock_frequency / (8 * sizeof(int32_t)) / sample_rate;
+}
+
+inline mic_dual_third_stage_coef_t *mic_array_third_stage_coefs(
+        const unsigned decimation_factor)
+{
+    mic_dual_third_stage_coef_t * const fir_coefs[7] = {
+            NULL,
+            g_third_stage_div_2_fir_dual,
+            g_third_stage_div_4_fir_dual,
+            g_third_stage_div_6_fir_dual,
+            g_third_stage_div_8_fir_dual,
+            NULL,
+            g_third_stage_div_12_fir_dual
+    };
+
+    return fir_coefs[decimation_factor/2];
+}
+
+inline int mic_array_fir_compensation(
+        const unsigned decimation_factor)
+{
+    const int fir_gain_compen[7] = {
+            0,
+            FIR_COMPENSATOR_DIV_2,
+            FIR_COMPENSATOR_DIV_4,
+            FIR_COMPENSATOR_DIV_6,
+            FIR_COMPENSATOR_DIV_8,
+            0,
+            FIR_COMPENSATOR_DIV_12
+    };
+
+    return fir_gain_compen[decimation_factor/2];
+}
+
+#endif /* MIC_SUPPORT_H_ */

--- a/examples/MEML/UART_example/src/platform/platform_init.h
+++ b/examples/MEML/UART_example/src/platform/platform_init.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2021 XMOS LIMITED. This Software is subject to the terms of the
+// XMOS Public License: Version 1
+
+#ifndef PLATFORM_INIT_H_
+#define PLATFORM_INIT_H_
+
+/* System headers */
+#include <platform.h>
+#include <xcore/chanend.h>
+
+/* Platform headers */
+#include "soc.h"
+#include "xcore_utils.h"
+#include "mic_array.h"
+#include "mic_array_vanilla.h"
+
+/* App headers */
+#include "tile_support.h"
+#include "app_pll_ctrl.h"
+#include "aic3204.h"
+
+/** TILE 0 Clock Blocks */
+#define SPI_CLKBLK      XS1_CLKBLK_1
+#define FLASH_CLKBLK    XS1_CLKBLK_2
+#define MCLK_CLKBLK     XS1_CLKBLK_3
+// #define UNUSED_CLKBLK     XS1_CLKBLK_4
+// #define UNUSED_CLKBLK   XS1_CLKBLK_5
+
+/** TILE 1 Clock Blocks */
+#define PDM_CLKBLK_1    XS1_CLKBLK_1
+#define PDM_CLKBLK_2    XS1_CLKBLK_2
+#define I2S_CLKBLK      XS1_CLKBLK_3
+// #define UNUSED_CLKBLK   XS1_CLKBLK_4
+// #define UNUSED_CLKBLK   XS1_CLKBLK_5
+
+void platform_init_tile_0(chanend_t c_other_tile);
+void platform_init_tile_1(chanend_t c_other_tile);
+
+#endif /* PLATFORM_INIT_H_ */

--- a/examples/MEML/UART_example/src/platform/platform_init_tile0.c
+++ b/examples/MEML/UART_example/src/platform/platform_init_tile0.c
@@ -1,0 +1,94 @@
+// Copyright (c) 2021 XMOS LIMITED. This Software is subject to the terms of the
+// XMOS Public License: Version 1
+
+/* App headers */
+#include "platform_init.h"
+
+static void tile0_setup_mclk(void);
+static void tile0_init_i2c(void);
+static void tile0_init_spi(void);
+static void tile0_init_spi_device(spi_master_t *spi_ctx);
+static void tile0_init_flash(void);
+
+void platform_init_tile_0(chanend_t c_other_tile)
+{
+    memset(tile0_ctx, 0, sizeof(tile0_ctx_t));
+
+    tile0_ctx->c_from_gpio = soc_channel_establish(c_other_tile, soc_channel_output);
+    tile0_ctx->c_to_gpio = soc_channel_establish(c_other_tile, soc_channel_input);
+
+    tile0_setup_mclk();
+
+    /* Wait for CODEC reset to be complete */
+    (void)chanend_in_byte(c_other_tile);
+
+    tile0_init_i2c();
+
+    /* Configure DAC */
+    if (aic3204_init(&(tile0_ctx->i2c_ctx)) != 0) {
+        debug_printf("DAC Failed\n");
+        chanend_out_byte(c_other_tile, 0x01);
+    } else {
+        debug_printf("DAC Initialized\n");
+        chanend_out_byte(c_other_tile, 0x00);
+    }
+
+    tile0_init_spi();
+    tile0_init_spi_device(&tile0_ctx->spi_ctx);
+
+    tile0_init_flash();
+}
+
+static void tile0_init_spi(void)
+{
+    spi_master_init(&tile0_ctx->spi_ctx,
+        SPI_CLKBLK,
+        WIFI_CS_N,
+        WIFI_CLK,
+        WIFI_MOSI,
+        WIFI_MISO);
+}
+
+static void tile0_init_spi_device(spi_master_t *spi_ctx)
+{
+    spi_master_device_init(&tile0_ctx->spi_device_ctx,
+        spi_ctx,
+        1, /* WiFi CS pin is on bit 1 of the CS port */
+        SPI_MODE_0,
+        spi_master_source_clock_ref,
+        0, /* 50 MHz */
+        spi_master_sample_delay_0,
+        0, 1 ,0 ,0 );
+}
+
+static void tile0_setup_mclk(void)
+{
+    port_enable(PORT_MCLK_IN);
+    clock_enable(MCLK_CLKBLK);
+    clock_set_source_port(MCLK_CLKBLK, PORT_MCLK_IN);
+    port_set_clock(PORT_MCLK_IN, MCLK_CLKBLK);
+    clock_start(MCLK_CLKBLK);
+}
+
+static void tile0_init_i2c(void)
+{
+    i2c_master_init(
+            &(tile0_ctx->i2c_ctx),
+            PORT_I2C_SCL, 0, 0,
+            PORT_I2C_SDA, 0, 0,
+            100); /* kbps */
+}
+
+static void tile0_init_flash(void)
+{
+
+    fl_QSPIPorts qspi_ports;
+    qspi_ports.qspiCS = PORT_SQI_CS;
+    qspi_ports.qspiSCLK = PORT_SQI_SCLK;
+    qspi_ports.qspiSIO = PORT_SQI_SIO;
+    qspi_ports.qspiClkblk = FLASH_CLKBLK;
+
+    fl_QuadDeviceSpec default_spec = FL_QUADDEVICE_DEFAULT;
+    fl_connectToDevice(&qspi_ports, &default_spec, 1);
+    fl_quadEnable();
+}

--- a/examples/MEML/UART_example/src/platform/platform_init_tile1.c
+++ b/examples/MEML/UART_example/src/platform/platform_init_tile1.c
@@ -1,0 +1,138 @@
+// Copyright (c) 2021-2022 XMOS LIMITED. This Software is subject to the terms of the
+// XMOS Public License: Version 1
+
+/* App headers */
+#include "../app_conf.h"
+#include "platform_init.h"
+
+static void tile1_setup_dac(void);
+static void tile1_i2s_init(void);
+static void tile1_mic_init(void);
+static void tile1_uart_init(void);
+
+void platform_init_tile_1(chanend_t c_other_tile)
+{
+    memset(tile1_ctx, 0, sizeof(tile1_ctx_t));
+
+    tile1_ctx->c_from_gpio = soc_channel_establish(c_other_tile, soc_channel_input);
+    tile1_ctx->c_to_gpio = soc_channel_establish(c_other_tile, soc_channel_output);
+
+    /* Reset CODEC */
+    tile1_setup_dac();
+
+    /* Signal codec reset complete */
+    chanend_out_byte(c_other_tile, 0x00);
+
+    /* Wait for DAC initialization to be complete */
+    char ret_char = chanend_in_byte(c_other_tile);
+    if (ret_char != 0) {
+        debug_printf("DAC init failed on other tile\n");
+    }
+
+    app_pll_init();
+
+    tile1_mic_init();
+    tile1_i2s_init();
+    tile1_uart_init();
+}
+
+static void tile1_setup_dac(void)
+{
+    const port_t codec_rst_port = PORT_CODEC_RST_N;
+    port_enable(codec_rst_port);
+    port_out(codec_rst_port, 0xF);
+}
+
+static int i2s_mclk_bclk_ratio(
+        const unsigned audio_clock_frequency,
+        const unsigned sample_rate)
+{
+    return audio_clock_frequency / (sample_rate * (8 * sizeof(int32_t)) * I2S_CHANS_PER_FRAME);
+}
+
+I2S_CALLBACK_ATTR
+static void i2s_init(chanend_t *input_c, i2s_config_t *i2s_config)
+{
+    i2s_config->mode = I2S_MODE_I2S;
+    i2s_config->mclk_bclk_ratio =  i2s_mclk_bclk_ratio(appconfAUDIO_CLOCK_FREQUENCY, appconfPIPELINE_AUDIO_SAMPLE_RATE);
+}
+
+I2S_CALLBACK_ATTR
+static i2s_restart_t i2s_restart_check(chanend_t *input_c)
+{
+    return I2S_NO_RESTART;
+}
+
+I2S_CALLBACK_ATTR
+static void i2s_receive(chanend_t *input_c, size_t num_in, const int32_t *i2s_sample_buf)
+{
+    return;
+}
+
+I2S_CALLBACK_ATTR
+static void i2s_send(chanend_t *input_c, size_t num_out, int32_t *i2s_sample_buf)
+{
+    s_chan_in_buf_word(*input_c, (uint32_t*)i2s_sample_buf, MIC_ARRAY_CONFIG_MIC_COUNT);
+}
+
+static void tile1_i2s_init(void)
+{
+    tile1_ctx->i2s_cb_group.init = (i2s_init_t) i2s_init;
+    tile1_ctx->i2s_cb_group.restart_check = (i2s_restart_check_t) i2s_restart_check;
+    tile1_ctx->i2s_cb_group.receive = (i2s_receive_t) i2s_receive;
+    tile1_ctx->i2s_cb_group.send = (i2s_send_t) i2s_send;
+    tile1_ctx->i2s_cb_group.app_data = &tile1_ctx->c_i2s_to_dac;
+
+    tile1_ctx->p_i2s_dout[0] = PORT_I2S_DAC_DATA;
+    tile1_ctx->p_bclk = PORT_I2S_BCLK;
+    tile1_ctx->p_lrclk = PORT_I2S_LRCLK;
+    tile1_ctx->p_mclk = PORT_MCLK_IN;
+    tile1_ctx->bclk = I2S_CLKBLK;
+}
+
+static void tile1_mic_init(void)
+{
+    ma_vanilla_init();
+}
+
+HIL_UART_RX_CALLBACK_ATTR
+void uart_rx_error_callback(uart_callback_code_t callback_code, void *app_data){
+    //debug_printf("uart_rx_error: 0x%x\n", callback_code);
+}
+
+static void tile1_uart_init(void)
+{
+    const unsigned baud_rate = 921600;
+
+    hwtimer_t tmr_tx = hwtimer_alloc();
+    uart_tx_init(
+        &tile1_ctx->uart_tx_ctx,
+        XS1_PORT_1P,  //X1D39
+        baud_rate,
+        8,
+        UART_PARITY_NONE,
+        1,
+        tmr_tx,
+        NULL,
+        0,
+        NULL,
+        NULL
+        );
+
+    hwtimer_t tmr_rx = hwtimer_alloc();
+    uart_rx_init(
+        &tile1_ctx->uart_rx_ctx,
+        XS1_PORT_1M, //X1D36
+        baud_rate,
+        8,
+        UART_PARITY_NONE,
+        1,
+        tmr_rx,
+        NULL, // No buffer
+        0,
+        NULL, // No rx complete callback
+        uart_rx_error_callback,
+        &tile1_ctx->uart_rx_ctx
+        );
+}
+

--- a/examples/MEML/UART_example/src/platform/tile_support.c
+++ b/examples/MEML/UART_example/src/platform/tile_support.c
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 XMOS LIMITED. This Software is subject to the terms of the
+// XMOS Public License: Version 1
+
+#include "tile_support.h"
+
+static tile0_ctx_t tile0_ctx_s;
+tile0_ctx_t *tile0_ctx = &tile0_ctx_s;
+
+static tile1_ctx_t tile1_ctx_s;
+tile1_ctx_t *tile1_ctx = &tile1_ctx_s;

--- a/examples/MEML/UART_example/src/platform/tile_support.h
+++ b/examples/MEML/UART_example/src/platform/tile_support.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2021-2022 XMOS LIMITED. This Software is subject to the terms of the
+// XMOS Public License: Version 1
+
+#ifndef TILE_SUPPORT_H_
+#define TILE_SUPPORT_H_
+
+#include <xcore/chanend.h>
+
+#include "i2c.h"
+#include "i2s.h"
+#include "spi.h"
+#include "mic_array.h"
+#include "uart.h"
+
+#include <quadflash.h>
+#include <quadflashlib.h>
+
+typedef struct tile0_struct tile0_ctx_t;
+struct tile0_struct {
+    chanend_t c_from_gpio;
+    chanend_t c_to_gpio;
+    spi_master_device_t spi_device_ctx;
+    spi_master_t spi_ctx;
+    i2c_master_t i2c_ctx;
+};
+
+typedef struct tile1_struct tile1_ctx_t;
+struct tile1_struct {
+    chanend_t c_from_gpio;
+    chanend_t c_to_gpio;
+
+    i2s_callback_group_t i2s_cb_group;
+    port_t p_i2s_dout[1];
+    port_t p_bclk;
+    port_t p_lrclk;
+    port_t p_mclk;
+    xclock_t bclk;
+    chanend_t c_i2s_to_dac;
+
+    uart_rx_t uart_rx_ctx;
+    uart_tx_t uart_tx_ctx;
+};
+
+extern tile0_ctx_t *tile0_ctx;
+extern tile1_ctx_t *tile1_ctx;
+
+#endif /* TILE_SUPPORT_H_ */

--- a/examples/examples.cmake
+++ b/examples/examples.cmake
@@ -1,5 +1,8 @@
 ## XCORE_XS3A only examples
 if(${CMAKE_SYSTEM_NAME} STREQUAL XCORE_XS3A)
+    ## MEML examples
+    include(${CMAKE_CURRENT_LIST_DIR}/MEML/UART_example/UART_example.cmake)
+    
     ## Bare metal examples
     include(${CMAKE_CURRENT_LIST_DIR}/bare-metal/explorer_board/explorer_board.cmake)
     include(${CMAKE_CURRENT_LIST_DIR}/bare-metal/visual_wake_words/visual_wake_words.cmake)


### PR DESCRIPTION
This is a proposed folder structure that might work for organising our projects under.

It includes a modified copy of the bare_metal example for the explorer board, retitled `UART_example` since that's what we're using it for. The modifications make it work for the `XK-EVK-XU316` board that Chris and I have.

As such most files have no significant edits but are instead copied over from the other example.

Here's an outline of the file structure alongside the original examples. We can expand on this to create other folders for e.g. production code:

```
examples/
├── bare-metal
│   ├── explorer_board
│   │   └── src
│   │       ├── audio_pipeline
│   │       ├── demos
│   │       ├── misc
│   │       └── platform
│   └── visual_wake_words
│       ├── model
│       └── src
└── MEML
    └── UART_example
        └── src
            ├── audio_pipeline
            ├── demos
            ├── misc
            └── platform
    └── SOME_OTHER_DEMO
        └── src
```


The only files with real changes in my example are:

examples/examples.cmake
examples/MEML/UART_example/README.md
examples/MEML/UART_example/UART_example.cmake
examples/MEML/UART_example/XK-EVK-XU316.xn